### PR TITLE
 format with %08x not handling numbers greater than 32bit int

### DIFF
--- a/md5.lua
+++ b/md5.lua
@@ -373,7 +373,7 @@ function md5.tohex(s)
   do
     tb[i] = format("%02x", str2bei(sub(s, arg, arg)))
   end
-  return tb:concat()
+  return table.concat(tb)
 end
 
 function md5.sum(s)

--- a/md5.lua
+++ b/md5.lua
@@ -369,10 +369,9 @@ end
 
 function md5.tohex(s)
   local tb = {}
-  for i = 1..8
+  for i = 1..16
   do
-    arg = i * 2
-    tb[i] = format("%04x", str2bei(sub(s, arg - 1, arg)))
+    tb[i] = format("%02x", str2bei(sub(s, arg, arg)))
   end
   return tb:concat()
 end

--- a/md5.lua
+++ b/md5.lua
@@ -368,7 +368,13 @@ function md5.new()
 end
 
 function md5.tohex(s)
-  return format("%08x%08x%08x%08x", str2bei(sub(s, 1, 4)), str2bei(sub(s, 5, 8)), str2bei(sub(s, 9, 12)), str2bei(sub(s, 13, 16)))
+  local tb = {}
+  for i = 1..8
+  do
+    arg = i * 2
+    tb[i] = format("%04x", str2bei(sub(s, arg - 1, arg)))
+  end
+  return tb:concat()
 end
 
 function md5.sum(s)


### PR DESCRIPTION
When using the md5 library to hash a message I got the following error
```
usr/bin/lua: ./md5.lua:416: bad argument #3 to 'format' (integer expected, got number)
stack traceback:
       [C]: in function 'format'
       ./md5.lua:416: in function 'tohex'
```
Changing format() from %08x with 4 bytes to %02x with 1 byte fixed the execution