### PR TITLE
format with %08x not handling numbers greater than 32bit int

### DIFF
--- a/md5.lua
+++ b/md5.lua
@@ -368,7 +368,12 @@ function md5.new()
 end
 
 function md5.tohex(s)
-  return format("%08x%08x%08x%08x", str2bei(sub(s, 1, 4)), str2bei(sub(s, 5, 8)), str2bei(sub(s, 9, 12)), str2bei(sub(s, 13, 16)))
+  local tb = {}
+  for i = 1..16
+  do
+    tb[i] = format("%02x", byte(s,i))
+  end
+  return table.concat(tb)
 end
 
 function md5.sum(s)


### PR DESCRIPTION
When using the md5 library to hash a message I got the following error
```
usr/bin/lua: ./md5.lua:416: bad argument #3 to 'format' (integer expected, got number)
stack traceback:
       [C]: in function 'format'
       ./md5.lua:416: in function 'tohex'
```
Changing format() from %08x with 4 bytes to bytewise format fixed the execution